### PR TITLE
Make main point to a no-op

### DIFF
--- a/node.js
+++ b/node.js
@@ -1,0 +1,1 @@
+module.exports = function () {}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "http://quilljs.com",
-  "main": "dist/quill.js",
+  "browser": "dist/quill.js",
+  "main": "node.js",
   "style": "dist/quill.snow.js",
   "files": [
     "assets",


### PR DESCRIPTION
And point the browser to the dist version. This allows us to require quill
on the server end for proper rendering, but not have to deal with the fact
that quill does bad things